### PR TITLE
Sender

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -13,7 +13,8 @@ import (
 
 // Conn is a mobile client connection.
 type Conn struct {
-	Session           Session
+	ID                string // Randomly generated unique connection ID
+	Session           *Session
 	conn              *tls.Conn
 	headerSize        int
 	maxMsgSize        int
@@ -41,7 +42,8 @@ func NewConn(conn *tls.Conn, headerSize, maxMsgSize, readWriteDeadline int, debu
 	}
 
 	return &Conn{
-		Session:           Session{ID: id},
+		ID:                id,
+		Session:           NewSession(),
 		conn:              conn,
 		headerSize:        headerSize,
 		maxMsgSize:        maxMsgSize,

--- a/context.go
+++ b/context.go
@@ -1,7 +1,0 @@
-package neptulon
-
-// Context encapsulates connection, request, and reponse objects.
-type Context struct {
-	conn *Conn
-	msg  []byte
-}

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -1,0 +1,39 @@
+package jsonrpc
+
+import "github.com/nbusy/neptulon"
+
+// ReqContext encapsulates connection, request, and reponse objects for a JSON-RPC request.
+type ReqContext struct {
+	conn    *neptulon.Conn
+	req     *Request
+	res     interface{}
+	resErr  *ResError
+	handled bool
+}
+
+// Res returns the response object if it was set.
+func (r *ReqContext) Res() interface{} {
+	return nil
+}
+
+// SetRes sets the response object and marks the request handled.
+func (r *ReqContext) SetRes(res interface{}) {
+	r.handled = true
+}
+
+// Handled returns true if a response was set or if the request was explicitly marked handled.
+func (r *ReqContext) Handled() bool {
+	return r.handled
+}
+
+// SetHandled marks the request as handled. This is automatically done when SetRes is used.
+func (r *ReqContext) SetHandled() bool {
+	return r.handled
+}
+
+// NotContext encapsulates connection and notification objects for a JSON-RPC notification.
+type NotContext struct {
+	conn    *neptulon.Conn
+	not     *Notification
+	handled bool
+}

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -10,8 +10,7 @@ import (
 
 // App is a Neptulon JSON-RPC app.
 type App struct {
-	inMiddleware []func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)
-	// outMiddleware []func(conn *neptulon.Conn, msg *Message)
+	middleware []func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)
 }
 
 // NewApp creates a Neptulon JSON-RPC app.
@@ -23,7 +22,7 @@ func NewApp(n *neptulon.App) (*App, error) {
 
 // Middleware registers a new middleware to handle incoming messages.
 func (a *App) Middleware(middleware func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)) {
-	a.inMiddleware = append(a.inMiddleware, middleware)
+	a.middleware = append(a.middleware, middleware)
 }
 
 func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
@@ -32,7 +31,7 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 		log.Fatalln("Cannot deserialize incoming message:", err)
 	}
 
-	for _, mid := range a.inMiddleware {
+	for _, mid := range a.middleware {
 		res, resErr := mid(conn, &m)
 		if res == nil && resErr == nil {
 			continue

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -10,7 +10,8 @@ import (
 
 // App is a Neptulon JSON-RPC app.
 type App struct {
-	middleware []func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)
+	inMiddleware []func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)
+	// outMiddleware []func(conn *neptulon.Conn, msg *Message)
 }
 
 // NewApp creates a Neptulon JSON-RPC app.
@@ -22,7 +23,7 @@ func NewApp(n *neptulon.App) (*App, error) {
 
 // Middleware registers a new middleware to handle incoming messages.
 func (a *App) Middleware(middleware func(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError)) {
-	a.middleware = append(a.middleware, middleware)
+	a.inMiddleware = append(a.inMiddleware, middleware)
 }
 
 func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
@@ -31,7 +32,7 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 		log.Fatalln("Cannot deserialize incoming message:", err)
 	}
 
-	for _, mid := range a.middleware {
+	for _, mid := range a.inMiddleware {
 		res, resErr := mid(conn, &m)
 		if res == nil && resErr == nil {
 			continue

--- a/jsonrpc/sender.go
+++ b/jsonrpc/sender.go
@@ -2,11 +2,11 @@ package jsonrpc
 
 import "github.com/nbusy/neptulon"
 
-// Sender is a JSON-RPC request sending middleware. This should be registered before any incoming request routers.
+// Sender is a JSON-RPC request/notification sending middleware.
 type Sender struct {
-	routes map[string]func(conn *neptulon.Conn, session *neptulon.Session, msg *Message)
+	routes map[string]func(conn *neptulon.Conn, msg *Message)
 }
 
-func (s *Sender) middleware(conn *neptulon.Conn, session *neptulon.Session, msg *Message) {
-	s.routes[msg.Method](conn, session, msg)
+func (s *Sender) middleware(conn *neptulon.Conn, msg *Message) {
+	s.routes[msg.Method](conn, msg)
 }

--- a/jsonrpc/sender.go
+++ b/jsonrpc/sender.go
@@ -27,9 +27,9 @@ func (s *Sender) Request(connID string, req *Request) chan<- *Response {
 	return ch
 }
 
-// Notification sends a JSON-RPC notification throught the connection denoted by the session ID.
-func (s *Sender) Notification(sessionID string, not *Notification) {
-
+// Notification sends a JSON-RPC notification throught the connection denoted by the connection ID.
+func (s *Sender) Notification(connID string, not *Notification) {
+	s.jsonrpc.Send(connID, not)
 }
 
 func (s *Sender) middleware(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError) {

--- a/jsonrpc/sender.go
+++ b/jsonrpc/sender.go
@@ -1,6 +1,11 @@
 package jsonrpc
 
-import "github.com/nbusy/neptulon"
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/nbusy/neptulon"
+)
 
 // Sender is a JSON-RPC request/notification sending middleware.
 type Sender struct {
@@ -19,6 +24,16 @@ func NewSender(app *App) (*Sender, error) {
 
 // Request sends a JSON-RPC request throught the connection denoted by the session ID.
 func (s *Sender) Request(sessionID string, req *Request) chan<- *Response {
+	data, err := json.Marshal(req)
+	if err != nil {
+		log.Fatalln("Cannot serialize outgoing request:", err)
+	}
+
+	_, err = conn.Write(data) // todo: delegate serialization to jsonrpc app which should delegate writing to neptulon app
+	if err != nil {
+		log.Fatalln("Errored while writing response to connection:", err)
+	}
+
 	ch := make(chan *Response)
 	s.pendinRequests[req.ID] = ch
 	return ch

--- a/jsonrpc/sender.go
+++ b/jsonrpc/sender.go
@@ -4,9 +4,16 @@ import "github.com/nbusy/neptulon"
 
 // Sender is a JSON-RPC request/notification sending middleware.
 type Sender struct {
-	routes map[string]func(conn *neptulon.Conn, msg *Message)
+	pendinRequests map[string]bool
 }
 
-func (s *Sender) middleware(conn *neptulon.Conn, msg *Message) {
-	s.routes[msg.Method](conn, msg)
+func (s *Sender) Request(req *Request) {
+	s.pendinRequests[req.ID] = true
+}
+
+func (s *Sender) middleware(conn *neptulon.Conn, res *Response) {
+	if s.pendinRequests[res.ID] {
+		// ...
+		delete(s.pendinRequests, res.ID)
+	}
 }

--- a/neptulon.go
+++ b/neptulon.go
@@ -52,6 +52,12 @@ func (a *App) Run() error {
 	return err
 }
 
+// Send sends a message throught the connection denoted by the connection ID.
+func (a *App) Send(connID string, msg []byte) error {
+	_, err := a.conns[connID].Write(msg)
+	return err
+}
+
 // Stop stops a server instance.
 func (a *App) Stop() error {
 	err := a.listener.Close()
@@ -78,7 +84,7 @@ func (a *App) Stop() error {
 func handleConn(a *App) func(conn *Conn) {
 	return func(conn *Conn) {
 		a.connMutex.Lock()
-		a.conns[conn.Session.ID] = conn
+		a.conns[conn.ID] = conn
 		a.connMutex.Unlock()
 	}
 }
@@ -103,7 +109,7 @@ func handleMsg(a *App) func(conn *Conn, msg []byte) {
 func handleDisconn(a *App) func(conn *Conn) {
 	return func(conn *Conn) {
 		a.connMutex.Lock()
-		delete(a.conns, conn.Session.ID)
+		delete(a.conns, conn.ID)
 		a.connMutex.Unlock()
 	}
 }

--- a/session.go
+++ b/session.go
@@ -4,11 +4,15 @@ import "sync"
 
 // Session is a session data store for connections.
 type Session struct {
-	ID           string // Auto generated session ID
 	error        error
 	disconnected bool
 	data         map[string]interface{}
 	mutex        sync.RWMutex
+}
+
+// NewSession creates and returns a new session object.
+func NewSession() *Session {
+	return &Session{data: make(map[string]interface{})}
 }
 
 // Set stores a value for a given key in the session. This method is thread safe.


### PR DESCRIPTION
Initial sender implementation. This version lacks middleware support for outgoing messages and requires middleware with server->client sending capabilities to store a references to the app instance.

There is also some early work for a future conn/msg `context` class transition.