### PR TITLE
Communication context

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ nep, _ := neptulon.NewApp(cert, privKey, "127.0.0.1:3000", true)
 jrpc, _ := jsonrpc.NewApp(nep)
 rout, _ := jsonrpc.NewRouter(jrpc)
 
-rout.Request("echo", func(conn *neptulon.Conn, req *jsonrpc.Request) (res interface{}, err *jsonrpc.ResError) {
-	return req.Params, nil
+rout.Request("echo", func(ctx *jsonrpc.ReqContext) {
+	ctx.Res = ctx.Req.Params
 })
 ```
 

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -4,26 +4,40 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-
-	"github.com/nbusy/neptulon"
 )
 
-func authMiddleware(conn *neptulon.Conn, msg *Message) {
-	if conn.Session.Get("userid") != 0 {
+// CertAuth is a TLS certificate authentication middleware for Neptulon JSON-RPC app.
+type CertAuth struct {
+}
+
+// NewCertAuth creates and registers a new certificate authentication middleware instance with a Neptulon JSON-RPC app.
+func NewCertAuth(app *App) (*CertAuth, error) {
+	a := CertAuth{}
+	app.Middleware(a.middleware)
+	return &a, nil
+}
+
+func (a *CertAuth) middleware(ctx *Context) {
+	if ctx.Conn.Session.Get("userid") != 0 {
 		return
 	}
 
+	// possible responses:
+	// cert revoked
+	// cert expired
+	// cert invalid
+
 	// client certificate authorization: certificate is verified by the TLS listener instance so we trust it
-	peerCerts := conn.ConnectionState().PeerCertificates
+	peerCerts := ctx.Conn.ConnectionState().PeerCertificates
 	if len(peerCerts) > 0 {
 		idstr := peerCerts[0].Subject.CommonName
 		uid64, err := strconv.ParseUint(idstr, 10, 32)
 		if err != nil {
-			conn.Session.Set("error", fmt.Errorf("Cannot parse client message or method mismatched: %v", err))
+			ctx.Conn.Session.Set("error", fmt.Errorf("Cannot parse client message or method mismatched: %v", err))
 			return
 		}
 		userID := uint32(uid64)
 		log.Printf("Client connected with client certificate subject: %+v", peerCerts[0].Subject)
-		conn.Session.Set("userid", userID)
+		ctx.Conn.Session.Set("userid", userID)
 	}
 }

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -4,32 +4,32 @@ import "github.com/nbusy/neptulon"
 
 // ReqContext encapsulates connection, request, and reponse objects for a JSON-RPC request.
 type ReqContext struct {
-	conn    *neptulon.Conn
-	req     *Request
-	res     interface{}
-	resErr  *ResError
+	Conn    *neptulon.Conn
+	Req     *Request
+	Res     interface{}
+	ResErr  *ResError
 	handled bool
 }
 
-// Res returns the response object if it was set.
-func (r *ReqContext) Res() interface{} {
-	return nil
-}
-
-// SetRes sets the response object and marks the request handled.
-func (r *ReqContext) SetRes(res interface{}) {
-	r.handled = true
-}
-
-// Handled returns true if a response was set or if the request was explicitly marked handled.
-func (r *ReqContext) Handled() bool {
-	return r.handled
-}
-
-// SetHandled marks the request as handled. This is automatically done when SetRes is used.
-func (r *ReqContext) SetHandled() bool {
-	return r.handled
-}
+// // Res returns the response object if it was set.
+// func (r *ReqContext) Res() interface{} {
+// 	return nil
+// }
+//
+// // SetRes sets the response object and marks the request handled.
+// func (r *ReqContext) SetRes(res interface{}) {
+// 	r.handled = true
+// }
+//
+// // Handled returns true if a response was set or if the request was explicitly marked handled.
+// func (r *ReqContext) Handled() bool {
+// 	return r.handled
+// }
+//
+// // SetHandled marks the request as handled. This is automatically done when SetRes is used.
+// func (r *ReqContext) SetHandled() bool {
+// 	return r.handled
+// }
 
 // NotContext encapsulates connection and notification objects for a JSON-RPC notification.
 type NotContext struct {

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -2,6 +2,15 @@ package jsonrpc
 
 import "github.com/nbusy/neptulon"
 
+// Context encapsulates connection and generic JSON-RPC incoming message and response objects.
+type Context struct {
+	Conn    *neptulon.Conn
+	Msg     *Message
+	Res     interface{}
+	ResErr  *ResError
+	handled bool
+}
+
 // ReqContext encapsulates connection, request, and reponse objects for a JSON-RPC request.
 type ReqContext struct {
 	Conn    *neptulon.Conn

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -9,6 +9,7 @@ type Context struct {
 	Res     interface{}
 	ResErr  *ResError
 	handled bool
+	err     error // returns error to user (if not empty) and closes conn
 }
 
 // ReqContext encapsulates connection, request, and reponse objects for a JSON-RPC request.
@@ -18,6 +19,7 @@ type ReqContext struct {
 	Res     interface{}
 	ResErr  *ResError
 	handled bool
+	err     error // returns error to user (if not empty) and closes conn
 }
 
 // // Res returns the response object if it was set.
@@ -45,4 +47,5 @@ type NotContext struct {
 	conn    *neptulon.Conn
 	not     *Notification
 	handled bool
+	err     error // returns error to user (if not empty) and closes conn
 }

--- a/jsonrpc/router.go
+++ b/jsonrpc/router.go
@@ -4,15 +4,15 @@ import "github.com/nbusy/neptulon"
 
 // Router is a JSON-RPC request routing middleware.
 type Router struct {
-	requestRoutes      map[string]func(conn *neptulon.Conn, req *Request) (result interface{}, err *ResError)
-	notificationRoutes map[string]func(conn *neptulon.Conn, not *Notification)
+	requestRoutes      map[string]func(ctx *ReqContext)
+	notificationRoutes map[string]func(ctx *NotContext)
 }
 
 // NewRouter creates a JSON-RPC router instance and registers it with the Neptulon JSON-RPC app.
 func NewRouter(app *App) (*Router, error) {
 	r := Router{
-		requestRoutes:      make(map[string]func(conn *neptulon.Conn, req *Request) (result interface{}, err *ResError)),
-		notificationRoutes: make(map[string]func(conn *neptulon.Conn, not *Notification)),
+		requestRoutes:      make(map[string]func(ctx *ReqContext)),
+		notificationRoutes: make(map[string]func(ctx *NotContext)),
 	}
 
 	app.Middleware(r.middleware)
@@ -20,12 +20,12 @@ func NewRouter(app *App) (*Router, error) {
 }
 
 // Request adds a new request route registry.
-func (r *Router) Request(route string, handler func(conn *neptulon.Conn, req *Request) (result interface{}, err *ResError)) {
+func (r *Router) Request(route string, handler func(ctx *ReqContext)) {
 	r.requestRoutes[route] = handler
 }
 
 // Notification adds a new notification route registry.
-func (r *Router) Notification(route string, handler func(conn *neptulon.Conn, not *Notification)) {
+func (r *Router) Notification(route string, handler func(ctx *NotContext)) {
 	r.notificationRoutes[route] = handler
 }
 
@@ -38,13 +38,15 @@ func (r *Router) middleware(conn *neptulon.Conn, msg *Message) (result interface
 	// if request
 	if msg.ID != "" {
 		if handler, ok := r.requestRoutes[msg.Method]; ok {
-			if res, resErr := handler(conn, &Request{ID: msg.ID, Method: msg.Method, Params: msg.Params}); res != nil || resErr != nil {
-				return res, resErr
+			ctx := ReqContext{Conn: conn, Req: &Request{ID: msg.ID, Method: msg.Method, Params: msg.Params}}
+			if handler(&ctx); ctx.Res != nil || ctx.ResErr != nil {
+				return ctx.Res, ctx.ResErr
 			}
 		}
 	} else { // if notification
 		if handler, ok := r.notificationRoutes[msg.Method]; ok {
-			handler(conn, &Notification{Method: msg.Method, Params: msg.Params})
+			ctx := NotContext{conn: conn, not: &Notification{Method: msg.Method, Params: msg.Params}}
+			handler(&ctx)
 			// todo: need to return something to prevent deeper handlers to further handle this request (i.e. not found handler logging not found warning)
 		}
 	}

--- a/jsonrpc/sender.go
+++ b/jsonrpc/sender.go
@@ -1,7 +1,5 @@
 package jsonrpc
 
-import "github.com/nbusy/neptulon"
-
 // Sender is a JSON-RPC request/notification sending middleware.
 type Sender struct {
 	jsonrpc        *App
@@ -32,11 +30,9 @@ func (s *Sender) Notification(connID string, not *Notification) {
 	s.jsonrpc.Send(connID, not)
 }
 
-func (s *Sender) middleware(conn *neptulon.Conn, msg *Message) (result interface{}, resErr *ResError) {
-	if ch, ok := s.pendinRequests[msg.ID]; ok {
-		ch <- &Response{ID: msg.ID, Result: msg.Result, Error: msg.Error}
-		delete(s.pendinRequests, msg.ID)
+func (s *Sender) middleware(ctx *Context) {
+	if ch, ok := s.pendinRequests[ctx.Msg.ID]; ok {
+		ch <- &Response{ID: ctx.Msg.ID, Result: ctx.Msg.Result, Error: ctx.Msg.Error}
+		delete(s.pendinRequests, ctx.Msg.ID)
 	}
-
-	return nil, nil
 }


### PR DESCRIPTION
Now all the middleware parameters and return values are wrapper inside a single `ctx` parameters for simplified middleware function signatures. Fixes #12