### PR TITLE
Connection close support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Example
 
 ```go
 nep, _ := neptulon.NewApp(cert, privKey, "127.0.0.1:3000", true)
-jrpc, _ := jsonrpc.NewApp(nep)
-rout, _ := jsonrpc.NewRouter(jrpc)
+rpc, _ := jsonrpc.NewApp(nep)
+rout, _ := jsonrpc.NewRouter(rpc)
 
 rout.Request("echo", func(ctx *jsonrpc.ReqContext) {
 	ctx.Res = ctx.Req.Params

--- a/conn.go
+++ b/conn.go
@@ -19,6 +19,8 @@ type Conn struct {
 	headerSize        int
 	maxMsgSize        int
 	readWriteDeadline time.Duration
+	error             error
+	disconnected      bool
 	debug             bool
 }
 
@@ -153,8 +155,7 @@ func (c *Conn) Write(msg []byte) (n int, err error) {
 
 // Close closes a connection.
 func (c *Conn) Close() error {
-	// todo: if session.err is nil, send a close req and wait ack then close? (or even wait for everything else to finish?)
-	return c.conn.Close()
+	return c.conn.Close() // todo: if conn.err is nil, send a close req and wait ack then close? (or even wait for everything else to finish?)
 }
 
 // RemoteAddr returns the remote network address.

--- a/conn.go
+++ b/conn.go
@@ -154,6 +154,7 @@ func (c *Conn) Write(msg []byte) (n int, err error) {
 }
 
 // Close closes a connection.
+// Note that TCP/IP stack does not guarantee delivery of messages before the connection is closed.
 func (c *Conn) Close() error {
 	return c.conn.Close() // todo: if conn.err is nil, send a close req and wait ack then close? (or even wait for everything else to finish?)
 }

--- a/conn.go
+++ b/conn.go
@@ -19,7 +19,7 @@ type Conn struct {
 	headerSize        int
 	maxMsgSize        int
 	readWriteDeadline time.Duration
-	error             error
+	err               error
 	disconnected      bool
 	debug             bool
 }

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -24,7 +24,7 @@ func (a *CertAuth) reqMiddleware(ctx *ReqContext) {
 	certs := ctx.Conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		ctx.ResErr = &ResError{Code: 666, Message: "Invalid client certificate.", Data: certs}
-		// ctx.Conn.Close()
+		ctx.Conn.Session.Set("close", true)
 		log.Println("Invalid client-certificate authentication attempt:", ctx.Conn.RemoteAddr())
 		return
 	}

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -24,6 +24,7 @@ func (a *CertAuth) reqMiddleware(ctx *ReqContext) {
 	certs := ctx.Conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		log.Println("Invalid client-certificate authentication attempt:", ctx.Conn.RemoteAddr())
+		ctx.Done = true
 		ctx.Conn.Close()
 		return
 	}
@@ -38,6 +39,7 @@ func (a *CertAuth) resMiddleware(ctx *ResContext) {
 		return
 	}
 
+	ctx.Done = true
 	ctx.Conn.Close()
 }
 
@@ -46,5 +48,6 @@ func (a *CertAuth) notMiddleware(ctx *NotContext) {
 		return
 	}
 
+	ctx.Done = true
 	ctx.Conn.Close()
 }

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -24,7 +24,7 @@ func (a *CertAuth) reqMiddleware(ctx *ReqContext) {
 	certs := ctx.Conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		ctx.ResErr = &ResError{Code: 666, Message: "Invalid client certificate.", Data: certs}
-		ctx.Conn.Close()
+		// ctx.Conn.Close()
 		log.Println("Invalid client-certificate authentication attempt:", ctx.Conn.RemoteAddr())
 		return
 	}

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -23,9 +23,8 @@ func (a *CertAuth) reqMiddleware(ctx *ReqContext) {
 	// if provided, client certificate is verified by the TLS listener so the peerCerts list in the connection is trusted
 	certs := ctx.Conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
-		ctx.ResErr = &ResError{Code: 666, Message: "Invalid client certificate.", Data: certs}
-		ctx.Conn.Session.Set("close", true)
 		log.Println("Invalid client-certificate authentication attempt:", ctx.Conn.RemoteAddr())
+		ctx.Conn.Close()
 		return
 	}
 

--- a/jsonrpc/auth.go
+++ b/jsonrpc/auth.go
@@ -24,8 +24,8 @@ func (a *CertAuth) reqMiddleware(ctx *ReqContext) {
 	certs := ctx.Conn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
 		ctx.ResErr = &ResError{Code: 666, Message: "Invalid client certificate.", Data: certs}
+		ctx.Conn.Close()
 		log.Println("Invalid client-certificate authentication attempt:", ctx.Conn.RemoteAddr())
-		// todo: Ctx.End / Conn.Close
 		return
 	}
 

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -4,53 +4,20 @@ import "github.com/nbusy/neptulon"
 
 // ReqContext encapsulates connection, request, and reponse objects for a request.
 type ReqContext struct {
-	Conn    *neptulon.Conn
-	Req     *Request
-	Res     interface{}
-	ResErr  *ResError
-	handled bool
-	closed  bool
-	err     error // returns error to user (if not empty) and closes conn
+	Conn   *neptulon.Conn
+	Req    *Request
+	Res    interface{}
+	ResErr *ResError
 }
-
-// Close closes the context object preventing any other registered middleware from handling the request.
-func (ctx *ReqContext) Close() *ReqContext {
-	ctx.closed = true
-	return ctx
-}
-
-// // Res returns the response object if it was set.
-// func (r *ReqContext) Res() interface{} {
-// 	return nil
-// }
-//
-// // SetRes sets the response object and marks the request handled.
-// func (r *ReqContext) SetRes(res interface{}) {
-// 	r.handled = true
-// }
-//
-// // Handled returns true if a response was set or if the request was explicitly marked handled.
-// func (r *ReqContext) Handled() bool {
-// 	return r.handled
-// }
-//
-// // SetHandled marks the request as handled. This is automatically done when SetRes is used.
-// func (r *ReqContext) SetHandled() bool {
-// 	return r.handled
-// }
 
 // NotContext encapsulates connection and notification objects.
 type NotContext struct {
-	Conn    *neptulon.Conn
-	Not     *Notification
-	handled bool
-	err     error // returns error to user (if not empty) and closes conn
+	Conn *neptulon.Conn
+	Not  *Notification
 }
 
 // ResContext encapsulates connection and response objects.
 type ResContext struct {
-	Conn    *neptulon.Conn
-	Res     *Response
-	handled bool
-	err     error // returns error to user (if not empty) and closes conn
+	Conn *neptulon.Conn
+	Res  *Response
 }

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -8,16 +8,19 @@ type ReqContext struct {
 	Req    *Request
 	Res    interface{}
 	ResErr *ResError
+	Done   bool // if set, this will prevent further middleware from handling the request
 }
 
 // NotContext encapsulates connection and notification objects.
 type NotContext struct {
 	Conn *neptulon.Conn
 	Not  *Notification
+	Done bool // if set, this will prevent further middleware from handling the request
 }
 
 // ResContext encapsulates connection and response objects.
 type ResContext struct {
 	Conn *neptulon.Conn
 	Res  *Response
+	Done bool // if set, this will prevent further middleware from handling the request
 }

--- a/jsonrpc/context.go
+++ b/jsonrpc/context.go
@@ -9,7 +9,14 @@ type ReqContext struct {
 	Res     interface{}
 	ResErr  *ResError
 	handled bool
+	closed  bool
 	err     error // returns error to user (if not empty) and closes conn
+}
+
+// Close closes the context object preventing any other registered middleware from handling the request.
+func (ctx *ReqContext) Close() *ReqContext {
+	ctx.closed = true
+	return ctx
 }
 
 // // Res returns the response object if it was set.

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -64,6 +64,9 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 			ctx := ReqContext{Conn: conn, Req: &Request{ID: m.ID, Method: m.Method, Params: m.Params}}
 			for _, mid := range a.reqMiddleware {
 				mid(&ctx)
+				if ctx.Conn.Session.Get("close") == true {
+					break
+				}
 			}
 
 			if ctx.Res != nil || ctx.ResErr != nil {

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -64,10 +64,9 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 			ctx := ReqContext{Conn: conn, Req: &Request{ID: m.ID, Method: m.Method, Params: m.Params}}
 			for _, mid := range a.reqMiddleware {
 				mid(&ctx)
-				if ctx.Res == nil && ctx.ResErr == nil {
-					continue
-				}
+			}
 
+			if ctx.Res != nil || ctx.ResErr != nil {
 				data, err := json.Marshal(Response{ID: m.ID, Result: ctx.Res, Error: ctx.ResErr})
 				if err != nil {
 					log.Fatalln("Errored while serializing JSON-RPC response:", err)

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -64,6 +64,9 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 			ctx := ReqContext{Conn: conn, Req: &Request{ID: m.ID, Method: m.Method, Params: m.Params}}
 			for _, mid := range a.reqMiddleware {
 				mid(&ctx)
+				if ctx.Done {
+					break
+				}
 			}
 
 			if ctx.Res != nil || ctx.ResErr != nil {
@@ -82,6 +85,9 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 		ctx := ResContext{Conn: conn, Res: &Response{ID: m.ID, Result: m.Result, Error: m.Error}}
 		for _, mid := range a.resMiddleware {
 			mid(&ctx)
+			if ctx.Done {
+				break
+			}
 		}
 
 		return nil
@@ -92,6 +98,9 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 		ctx := NotContext{Conn: conn, Not: &Notification{Method: m.Method, Params: m.Params}}
 		for _, mid := range a.notMiddleware {
 			mid(&ctx)
+			if ctx.Done {
+				break
+			}
 		}
 
 		return nil

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -64,9 +64,6 @@ func (a *App) neptulonMiddleware(conn *neptulon.Conn, msg []byte) []byte {
 			ctx := ReqContext{Conn: conn, Req: &Request{ID: m.ID, Method: m.Method, Params: m.Params}}
 			for _, mid := range a.reqMiddleware {
 				mid(&ctx)
-				if ctx.Conn.Session.Get("close") == true {
-					break
-				}
 			}
 
 			if ctx.Res != nil || ctx.ResErr != nil {

--- a/listener.go
+++ b/listener.go
@@ -94,7 +94,7 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 	handleConn(conn)
 
 	defer func() {
-		conn.error = conn.Close() // todo: handle close error, store the error in conn object and return it to handleMsg/handleErr/handleDisconn or one level up (to server)
+		conn.err = conn.Close() // todo: handle close error, store the error in conn object and return it to handleMsg/handleErr/handleDisconn or one level up (to server)
 		if conn.disconnected {
 			log.Println("Client disconnected:", conn.RemoteAddr())
 		} else {
@@ -105,8 +105,8 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 	}()
 
 	for {
-		if conn.error != nil {
-			return conn.error // todo: should we send error message to user, log the error, and close the conn and return instead?
+		if conn.err != nil {
+			return conn.err // todo: should we send error message to user, log the error, and close the conn and return instead?
 		}
 
 		n, msg, err := conn.Read()
@@ -127,7 +127,7 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 			continue // send back pong?
 		}
 		if n == 5 && bytes.Equal(msg, closed) {
-			return conn.error
+			return conn.err
 		}
 
 		l.reqWG.Add(1)
@@ -137,7 +137,7 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 		}()
 	}
 
-	return conn.error
+	return conn.err
 }
 
 // Close closes the listener.

--- a/listener.go
+++ b/listener.go
@@ -94,8 +94,8 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 	handleConn(conn)
 
 	defer func() {
-		conn.Session.error = conn.Close() // todo: handle close error, store the error in conn object and return it to handleMsg/handleErr/handleDisconn or one level up (to server)
-		if conn.Session.disconnected {
+		conn.error = conn.Close() // todo: handle close error, store the error in conn object and return it to handleMsg/handleErr/handleDisconn or one level up (to server)
+		if conn.disconnected {
 			log.Println("Client disconnected:", conn.RemoteAddr())
 		} else {
 			log.Println("Closed client connection:", conn.RemoteAddr())
@@ -105,19 +105,18 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 	}()
 
 	for {
-		if conn.Session.error != nil {
-			// todo: send error message to user, log the error, and close the conn and return
-			return conn.Session.error
+		if conn.error != nil {
+			return conn.error // todo: should we send error message to user, log the error, and close the conn and return instead?
 		}
 
 		n, msg, err := conn.Read()
 		if err != nil {
 			if err == io.EOF {
-				conn.Session.disconnected = true
+				conn.disconnected = true
 				break
 			}
 			if operr, ok := err.(*net.OpError); ok && operr.Op == "read" && operr.Err.Error() == "use of closed network connection" {
-				conn.Session.disconnected = true
+				conn.disconnected = true
 				break
 			}
 			log.Fatalln("Errored while reading:", err)
@@ -128,7 +127,7 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 			continue // send back pong?
 		}
 		if n == 5 && bytes.Equal(msg, closed) {
-			return conn.Session.error
+			return conn.error
 		}
 
 		l.reqWG.Add(1)
@@ -138,7 +137,7 @@ func handleClient(l *Listener, conn *Conn, handleConn func(conn *Conn), handleMs
 		}()
 	}
 
-	return conn.Session.error
+	return conn.error
 }
 
 // Close closes the listener.

--- a/neptulon.go
+++ b/neptulon.go
@@ -4,7 +4,6 @@ package neptulon
 import (
 	"log"
 	"sync"
-	"time"
 )
 
 // App is a Neptulon application.
@@ -94,24 +93,16 @@ func handleMsg(a *App) func(conn *Conn, msg []byte) {
 	return func(conn *Conn, msg []byte) {
 		for _, m := range a.middleware {
 			res := m(conn, msg)
-			if res != nil {
-				_, err := conn.Write(res)
-				if err != nil {
-					log.Fatalln("Errored while writing response to connection:", err)
-				}
-
-				if conn.Session.Get("close") == true {
-					time.Sleep(time.Second)
-					conn.Close()
-				}
-
-				break
+			if res == nil {
+				continue
 			}
 
-			if conn.Session.Get("close") == true {
-				conn.Close()
-				break
+			_, err := conn.Write(res)
+			if err != nil {
+				log.Fatalln("Errored while writing response to connection:", err)
 			}
+
+			break
 		}
 	}
 }

--- a/session.go
+++ b/session.go
@@ -4,10 +4,8 @@ import "sync"
 
 // Session is a thread-safe data store.
 type Session struct {
-	error        error
-	disconnected bool
-	data         map[string]interface{}
-	mutex        sync.RWMutex
+	data  map[string]interface{}
+	mutex sync.RWMutex
 }
 
 // NewSession creates and returns a new session object.


### PR DESCRIPTION
TCP/IP does not guarantee the delivery of messages in case of connection close event so we switched from connection close events to ack-then-close style.